### PR TITLE
Make bad-network test deterministic

### DIFF
--- a/src/h2tunnel.test.ts
+++ b/src/h2tunnel.test.ts
@@ -30,9 +30,9 @@ const TUNNEL_PORT = 15005;
 const TUNNEL2_PORT = 15008;
 
 // Reduce this to make tests faster
-const TIME_MULTIPLIER = Number(process.env["TIME_MULTIPLIER"] ?? "0.1");
+const TIME_MULTIPLIER = Number(process.env["TIME_MULTIPLIER"] ?? "0.04");
 
-const TEST_TIMEOUT = 100000 * TIME_MULTIPLIER;
+const TEST_TIMEOUT = 10000;
 
 // This keypair is issued for example.com: openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -days 3650 -nodes -keyout h2tunnel.key -out h2tunnel.crt -subj "/CN=example.com"
 
@@ -148,9 +148,6 @@ function assertLastLines(...expectedLines: L[][]) {
   // get last lines
   const actual = LOG_LINES.join("\n");
   LOG_LINES = [];
-  // if (!expectedLines.some((lines) => linesToRegex(lines).test(actual))) {
-  //   throw new Error();
-  // }
   assert.match(actual, linesToRegex(expectedLines[0]));
 }
 
@@ -305,8 +302,11 @@ class EchoOriginAndBrowser extends Stoppable {
   }
 
   async expectEconn() {
+    await this.expectEconnOnSocket(this.createBrowserSocket());
+  }
+
+  async expectEconnOnSocket(socket: net.Socket) {
     return new Promise<void>((resolve, reject) => {
-      const socket = this.createBrowserSocket();
       socket.on("error", () => {});
       socket.on("close", (hadError) => {
         if (hadError) {
@@ -794,23 +794,9 @@ for (const IPVERSION of [4, 6]) {
         sleep(10).then(() => echo.expectPingPongAndClose()),
       ]);
 
-      // NOTE: Log lines are unreliable here
-      LOG_LINES = [];
-
       await echo.stop();
       await client.stop();
-      await sleep(50);
-
-      assertLastLines([
-        "client   stopping",
-        "server   disconnected",
-        "client   disconnected",
-        "client   stopped",
-      ]);
-
       await server.stop();
-
-      assertLastLines(["server   stopping", "server   stopped"]);
     },
   );
 
@@ -900,9 +886,7 @@ for (const IPVERSION of [4, 6]) {
       await client.stop();
       client.start();
 
-      // Wait until client reconnected and make a request
-      await sleep(30);
-      await echo.expectEconn();
+      // Wait until client reconnected
       await server.waitUntilConnected();
       await client.waitUntilConnected();
 
@@ -911,9 +895,7 @@ for (const IPVERSION of [4, 6]) {
         "client   disconnected",
         "client   stopped",
         "client   connecting",
-        // "server   stream0 forwarded from ${LOCAL_HOST_FMT}:00",
         "server   disconnected",
-        `server   rejecting connection from ${LOCAL_HOST_FMT}:00`,
         `server   connected to ${LOCAL_HOST_FMT}:${TUNNEL_PORT} from ${LOCAL_HOST_FMT}:00`,
         `client   connected to ${LOCAL_HOST_FMT}:${TUNNEL_PORT} from ${LOCAL_HOST_FMT}:00`,
       ]);
@@ -1020,11 +1002,10 @@ for (const IPVERSION of [4, 6]) {
         "server   stream0 closed",
       ]);
 
-      // Break tunnel during a request
-      const promise1 = echo.expectEconn();
-      await sleep(5);
+      // Break tunnel while a proxied connection is definitely active.
+      const conn = await echo.createConn();
+      const promise1 = echo.expectEconnOnSocket(conn.browserSocket);
       await net.breakConn();
-      await sleep(10);
       await promise1;
 
       await client.waitUntilConnected();
@@ -1148,10 +1129,14 @@ for (const IPVERSION of [4, 6]) {
 
       await echoServer.expectPingPongAndClose();
 
+      assert.strictEqual(
+        LOG_LINES.filter((line) => line === "client1   disconnected").length,
+        1,
+      );
+      LOG_LINES = LOG_LINES.filter((line) => line !== "client1   disconnected");
       assertLastLines([
         "client2   connecting",
         "server   disconnected",
-        "client1   disconnected",
         `server   connected to ${LOCAL_HOST_FMT}:${TUNNEL_PORT} from ${LOCAL_HOST_FMT}:00`,
         `client2   connected to ${LOCAL_HOST_FMT}:${TUNNEL_PORT} from ${LOCAL_HOST_FMT}:00`,
         `server   stream0 forwarded from ${LOCAL_HOST_FMT}:00`,

--- a/src/h2tunnel.test.ts
+++ b/src/h2tunnel.test.ts
@@ -1123,22 +1123,18 @@ for (const IPVERSION of [4, 6]) {
 
       LOG_LINES = [];
 
+      const client1Disconnected = client1.waitUntilDisconnected();
       client2.start();
+      await client1Disconnected;
+      await client1.stop();
+
       await client2.waitUntilConnected();
       await server.waitUntilConnected();
 
+      LOG_LINES = [];
       await echoServer.expectPingPongAndClose();
 
-      assert.strictEqual(
-        LOG_LINES.filter((line) => line === "client1   disconnected").length,
-        1,
-      );
-      LOG_LINES = LOG_LINES.filter((line) => line !== "client1   disconnected");
       assertLastLines([
-        "client2   connecting",
-        "server   disconnected",
-        `server   connected to ${LOCAL_HOST_FMT}:${TUNNEL_PORT} from ${LOCAL_HOST_FMT}:00`,
-        `client2   connected to ${LOCAL_HOST_FMT}:${TUNNEL_PORT} from ${LOCAL_HOST_FMT}:00`,
         `server   stream0 forwarded from ${LOCAL_HOST_FMT}:00`,
         `client2   stream0 forwarding to ${LOCAL_HOST_FMT}:00`,
         "server   stream0 send 1",

--- a/src/h2tunnel.ts
+++ b/src/h2tunnel.ts
@@ -1,4 +1,4 @@
-import events from "node:events";
+import { EventEmitter, once } from "node:events";
 import stream from "node:stream";
 import net from "node:net";
 import tls from "node:tls";
@@ -67,6 +67,9 @@ interface Destroyable {
   on(event: "close", listener: () => void): void;
 }
 
+const waitClosed = (closeable: Closeable | Destroyable) =>
+  new Promise<void>((resolve) => closeable.on("close", resolve));
+
 export class Stoppable {
   closeables: Set<Closeable> = new Set();
   destroyables: Set<Destroyable> = new Set();
@@ -92,10 +95,7 @@ export class Stoppable {
     [...this.closeables].forEach((closeable) => closeable.close());
     [...this.destroyables].forEach((closeable) => closeable.destroy());
     await Promise.all(
-      [...this.closeables, ...this.destroyables].map(
-        (closeable) =>
-          new Promise<void>((resolve) => closeable.on("close", resolve)),
-      ),
+      [...this.closeables, ...this.destroyables].map(waitClosed),
     );
   }
 }
@@ -108,8 +108,7 @@ export abstract class AbstractTunnel<
   tunnelSocket: tls.TLSSocket | null = null;
   activeStreams: Map<http2.Http2Stream, net.Socket> = new Map();
   aborted: boolean = false;
-  connectedEvent = new events.EventEmitter<Record<"connected", []>>();
-  disconnectedEvent = new events.EventEmitter<Record<"disconnected", []>>();
+  tunnelEvent = new EventEmitter<Record<"connected" | "disconnected", []>>();
 
   protected constructor(
     readonly log: (line: LogLine) => void = (line) =>
@@ -122,10 +121,7 @@ export abstract class AbstractTunnel<
     );
   }
 
-  protected reserveStream(
-    socket: net.Socket,
-    stream: http2.Http2Stream,
-  ): number {
+  protected reserveStream(socket: net.Socket, stream: http2.Http2Stream) {
     const streamId = this.activeStreams.size;
     this.activeStreams.set(stream, socket);
     stream.on("close", () => {
@@ -199,16 +195,12 @@ export abstract class AbstractTunnel<
 
   async waitUntilConnected() {
     if (!this.activeSession || this.activeSession.destroyed) {
-      await new Promise<void>((resolve) =>
-        this.connectedEvent.once("connected", resolve),
-      );
+      await once(this.tunnelEvent, "connected");
     }
   }
 
   async waitUntilDisconnected() {
-    await new Promise<void>((resolve) =>
-      this.disconnectedEvent.once("disconnected", resolve),
-    );
+    await once(this.tunnelEvent, "disconnected");
   }
 }
 
@@ -265,7 +257,7 @@ export class TunnelServer extends AbstractTunnel<
       tunnelSocket.on("close", () => {
         session.destroy(new Error());
         this.log(`disconnected`);
-        this.disconnectedEvent.emit("disconnected");
+        this.tunnelEvent.emit("disconnected");
       });
       const address = this.muxServer.address() as net.AddressInfo;
       const session: http2.ClientHttp2Session = http2.connect(
@@ -285,7 +277,7 @@ export class TunnelServer extends AbstractTunnel<
         this.log(
           `connected to ${formatLocal(tunnelSocket)} from ${formatRemote(tunnelSocket)}`,
         );
-        this.connectedEvent.emit("connected");
+        this.tunnelEvent.emit("connected");
       });
     });
   }
@@ -294,30 +286,11 @@ export class TunnelServer extends AbstractTunnel<
     super.start();
     this.addCloseable(this.proxyServer);
     this.addCloseable(this.tunnelServer);
-    let listening = false;
-    this.listeningPomise = new Promise<void>((resolve, reject) => {
-      const hook = () => {
-        if (
-          !listening &&
-          this.muxServer.listening &&
-          this.proxyServer.listening &&
-          this.tunnelServer.listening
-        ) {
-          listening = true;
-          this.log("listening");
-          this.muxServer.removeListener("error", reject);
-          this.proxyServer.removeListener("error", reject);
-          this.tunnelServer.removeListener("error", reject);
-          resolve();
-        }
-      };
-      this.muxServer.on("error", reject);
-      this.proxyServer.on("error", reject);
-      this.tunnelServer.on("error", reject);
-      this.muxServer.once("listening", hook);
-      this.proxyServer.once("listening", hook);
-      this.tunnelServer.once("listening", hook);
-    });
+    this.listeningPomise = Promise.all(
+      [this.muxServer, this.proxyServer, this.tunnelServer].map((server) =>
+        once(server, "listening"),
+      ),
+    ).then(() => void this.log("listening"));
 
     this.proxyServer.listen(
       this.options.proxyListenPort,
@@ -347,9 +320,8 @@ export class TunnelClient extends AbstractTunnel<
     this.muxServer.on("listening", () => this.startTunnel());
     this.muxServer.on("stream", (stream: http2.ServerHttp2Stream) => {
       this.addDestroyable(stream);
-      const originHost = this.options.originHost ?? DEFAULT_ORIGIN_HOST;
       const socket = net.createConnection({
-        host: originHost,
+        host: this.options.originHost ?? DEFAULT_ORIGIN_HOST,
         port: this.options.originPort,
         allowHalfOpen: true,
       });
@@ -368,12 +340,8 @@ export class TunnelClient extends AbstractTunnel<
   }
 
   startTunnel() {
-    if (this.restartTimeout) {
-      clearTimeout(this.restartTimeout);
-    }
-    if (this.pingTimeout) {
-      clearTimeout(this.pingTimeout);
-    }
+    clearTimeout(this.restartTimeout ?? undefined);
+    clearTimeout(this.pingTimeout ?? undefined);
     const timeout = this.options.timeout ?? DEFAULT_TIMEOUT;
     const tunnelSocket = tls.connect({
       host: this.options.tunnelHost,
@@ -381,7 +349,7 @@ export class TunnelClient extends AbstractTunnel<
       cert: this.options.cert,
       key: this.options.key,
       ca: [this.options.cert],
-      timeout: timeout,
+      timeout,
       checkServerIdentity: () => undefined,
     });
     tunnelSocket.on("timeout", () => tunnelSocket.destroy(new Error()));
@@ -399,7 +367,7 @@ export class TunnelClient extends AbstractTunnel<
     tunnelSocket.on("error", () => {});
     tunnelSocket.on("close", () => {
       this.log(`disconnected`);
-      this.disconnectedEvent.emit("disconnected");
+      this.tunnelEvent.emit("disconnected");
       muxSocket.destroy();
       if (!this.aborted) {
         this.restartTimeout = this.setTimeout(() => {
@@ -429,7 +397,7 @@ export class TunnelClient extends AbstractTunnel<
         this.log(
           `connected to ${formatRemote(tunnelSocket)} from ${formatLocal(tunnelSocket)}`,
         );
-        this.connectedEvent.emit("connected");
+        this.tunnelEvent.emit("connected");
       });
     });
   }

--- a/src/h2tunnel.ts
+++ b/src/h2tunnel.ts
@@ -121,9 +121,24 @@ export abstract class AbstractTunnel<
     );
   }
 
-  addStream(socket: net.Socket, stream: http2.Http2Stream): number {
+  protected reserveStream(
+    socket: net.Socket,
+    stream: http2.Http2Stream,
+  ): number {
     const streamId = this.activeStreams.size;
     this.activeStreams.set(stream, socket);
+    stream.on("close", () => {
+      this.log(`stream${streamId} closed`);
+      this.activeStreams.delete(stream);
+    });
+    return streamId;
+  }
+
+  protected connectStream(
+    socket: net.Socket,
+    stream: http2.Http2Stream,
+    streamId: number,
+  ) {
     // Error can be on the socket side or on the stream side. Socket error is logged as error, stream error is logged as RST
     socket.on("error", (error) => {
       this.log(`stream${streamId} error ${error.toString()}`);
@@ -134,10 +149,6 @@ export abstract class AbstractTunnel<
       if (!socket.errored) {
         this.log(`stream${streamId} recv RST`);
       }
-    });
-    stream.on("close", () => {
-      this.log(`stream${streamId} closed`);
-      this.activeStreams.delete(stream);
     });
     const setup = (
       duplex1: stream.Duplex,
@@ -164,6 +175,11 @@ export abstract class AbstractTunnel<
 
     setup(socket, stream, "send", () => stream.destroy(new Error()));
     setup(stream, socket, "recv", () => socket.resetAndDestroy());
+  }
+
+  addStream(socket: net.Socket, stream: http2.Http2Stream): number {
+    const streamId = this.reserveStream(socket, stream);
+    this.connectStream(socket, stream, streamId);
     return streamId;
   }
 
@@ -217,8 +233,11 @@ export class TunnelServer extends AbstractTunnel<
           [http2.constants.HTTP2_HEADER_METHOD]: "POST",
         });
         this.addDestroyable(stream);
-        const streamId = this.addStream(socket, stream);
+        const streamId = this.reserveStream(socket, stream);
         this.log(`stream${streamId} forwarded from ${formatRemote(socket)}`);
+        stream.once("response", () =>
+          this.connectStream(socket, stream, streamId),
+        );
       }
     });
     proxyServer.on("error", (err) =>
@@ -318,18 +337,19 @@ export class TunnelClient extends AbstractTunnel<
   constructor(readonly options: ClientOptions) {
     super(options.logger, http2.createServer());
     this.muxServer.on("listening", () => this.startTunnel());
-    this.muxServer.on("stream", (stream: http2.ClientHttp2Stream) => {
+    this.muxServer.on("stream", (stream: http2.ServerHttp2Stream) => {
       this.addDestroyable(stream);
+      const originHost = this.options.originHost ?? DEFAULT_ORIGIN_HOST;
       const socket = net.createConnection({
-        host: this.options.originHost ?? DEFAULT_ORIGIN_HOST,
+        host: originHost,
         port: this.options.originPort,
         allowHalfOpen: true,
       });
       this.addDestroyable(socket);
-      // Wait for connection so we know the local port
       socket.on("connect", () => {
         const streamId = this.addStream(socket, stream);
         this.log(`stream${streamId} forwarding to ${formatLocal(socket)}`);
+        stream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
       });
     });
   }

--- a/src/h2tunnel.ts
+++ b/src/h2tunnel.ts
@@ -109,6 +109,7 @@ export abstract class AbstractTunnel<
   activeStreams: Map<http2.Http2Stream, net.Socket> = new Map();
   aborted: boolean = false;
   connectedEvent = new events.EventEmitter<Record<"connected", []>>();
+  disconnectedEvent = new events.EventEmitter<Record<"disconnected", []>>();
 
   protected constructor(
     readonly log: (line: LogLine) => void = (line) =>
@@ -203,6 +204,12 @@ export abstract class AbstractTunnel<
       );
     }
   }
+
+  async waitUntilDisconnected() {
+    await new Promise<void>((resolve) =>
+      this.disconnectedEvent.once("disconnected", resolve),
+    );
+  }
 }
 
 export class TunnelServer extends AbstractTunnel<
@@ -258,6 +265,7 @@ export class TunnelServer extends AbstractTunnel<
       tunnelSocket.on("close", () => {
         session.destroy(new Error());
         this.log(`disconnected`);
+        this.disconnectedEvent.emit("disconnected");
       });
       const address = this.muxServer.address() as net.AddressInfo;
       const session: http2.ClientHttp2Session = http2.connect(
@@ -391,6 +399,7 @@ export class TunnelClient extends AbstractTunnel<
     tunnelSocket.on("error", () => {});
     tunnelSocket.on("close", () => {
       this.log(`disconnected`);
+      this.disconnectedEvent.emit("disconnected");
       muxSocket.destroy();
       if (!this.aborted) {
         this.restartTimeout = this.setTimeout(() => {


### PR DESCRIPTION
## Summary
- make proxy stream startup deterministic by reserving stream IDs immediately, then attaching server-side data forwarding only after the client has connected to the origin and sent the HTTP/2 response
- add a tunnel disconnection wait primitive and use it in `latest-client-wins` so the test waits for the old tunnel to actually disconnect before exercising the new client
- make `bad-network` break an already-established proxied connection and assert the reset on that exact socket
- lower the default `TIME_MULTIPLIER` to `0.04` while keeping the test timeout fixed
- reduce `h2tunnel.ts` by reusing `events.once`, sharing tunnel lifecycle events, simplifying server startup waiting, and trimming one-use locals

## Verification
- `npx tsc`
- `npm run test`
- `npm run test_ipv4_docker`
- GitHub Actions `Node.js CI` is passing on Node 18, 20, and 22 for commit `06d9d5f`