### PR TITLE
Add npm provenance release workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,9 +13,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,35 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - name: Check release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          release_version="${GITHUB_REF_NAME#v}"
+          if [ "$package_version" != "$release_version" ]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match package.json version ${package_version}"
+            exit 1
+          fi
+      - run: npm run build
+      - run: npm run test
+      - run: npm run test_ipv4_docker
+      - run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ npm run test
 npm run coverage # See build/index.html
 ```
 
+## Releasing
+
+Publishing to npm is automated by the
+[Publish to npm](https://github.com/boronine/h2tunnel/actions/workflows/npm-publish.yml) GitHub Actions workflow.
+It runs when a GitHub Release is published, builds and tests the package on a GitHub-hosted runner, and publishes with
+`npm publish --provenance` using npm trusted publishing so npm records a provenance attestation for the package.
+
+Configure npm trusted publishing for the `boronine/h2tunnel` repository and `npm-publish.yml` workflow before publishing
+the next release.
+
 ## CHANGELOG
 
 See [CHANGELOG.md](./CHANGELOG.md) file for full text.


### PR DESCRIPTION
## Summary
- add a GitHub Release-triggered npm publish workflow
- publish with `npm publish --provenance --access public` using GitHub OIDC/trusted publishing
- verify release tags match `package.json` before publishing
- document npm trusted publishing setup in the README

## Testing
- `npm test`
- `npm run test_ipv4_docker`
- `npm pack --dry-run`
- `npx prettier --check README.md .github/workflows/npm-publish.yml`